### PR TITLE
Added user suggested fixes for non-linearities at high lux values

### DIFF
--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -91,8 +91,11 @@ public:
 
 
   float readLux();
+  float readLuxNormalized();
+
   uint16_t readALS();
   float readWhite();
+  float readWhiteNormalized();
 
 private:
   Adafruit_I2CRegister *ALS_Config, *ALS_Data, *White_Data, 
@@ -101,7 +104,7 @@ private:
     *ALS_Persistence, *ALS_Integration_Time, *ALS_Gain,
     *PowerSave_Enable, *PowerSave_Mode;
 
-  float normalize(float value);
+  float normalize_resolution(float value);
 
   Adafruit_I2CDevice *i2c_dev;
 


### PR DESCRIPTION
This commit adds two new functions `readLuxNormalized`  and `readWhiteNormalized`
that use corrections supplied by a user to account for non-linearities in the chip at higher lux levels (25ms integration time, 1/8 gain).