### PR TITLE
Replaced deprecated boolean with bool

### DIFF
--- a/Adafruit_VEML7700.cpp
+++ b/Adafruit_VEML7700.cpp
@@ -42,7 +42,7 @@ Adafruit_VEML7700::Adafruit_VEML7700(void) {}
  *    @param  theWire An optional pointer to an I2C interface
  *    @return True if initialization was successful, otherwise false.
  */
-boolean Adafruit_VEML7700::begin(TwoWire *theWire) {
+bool Adafruit_VEML7700::begin(TwoWire *theWire) {
   i2c_dev = new Adafruit_I2CDevice(VEML7700_I2CADDR_DEFAULT, theWire);
 
   if (!i2c_dev->begin()) {

--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -64,7 +64,7 @@
 class Adafruit_VEML7700 {
 public:
   Adafruit_VEML7700();
-  boolean begin(TwoWire *theWire = &Wire);
+  bool begin(TwoWire *theWire = &Wire);
 
   void enable(bool enable);
   bool enabled(void);


### PR DESCRIPTION
Hi,

boolean type is deprecated in the official STM32 Arduino core, which causes some warnings when using this library. I replaced it with bool which should be supported by all the major Arduino cores, so it should be safe to use (and the library is already using it anyway).