### PR TITLE
Update Lux and other misc changes

### DIFF
--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -88,22 +88,21 @@ public:
   uint16_t getHighThreshold(void);
   uint16_t interruptStatus(void);
 
-  float readLux();
-  float readLuxNormalized();
-
   uint16_t readALS();
-  float readWhite();
-  float readWhiteNormalized();
+  uint16_t readWhite();
+  float readLux();
 
 private:
+  const float MAX_RES = 0.0036;
+  const float GAIN_MAX = 2;
+  const float IT_MAX = 800;
+  float getResolution();
+
   Adafruit_I2CRegister *ALS_Config, *ALS_Data, *White_Data, *ALS_HighThreshold,
       *ALS_LowThreshold, *Power_Saving, *Interrupt_Status;
   Adafruit_I2CRegisterBits *ALS_Shutdown, *ALS_Interrupt_Enable,
       *ALS_Persistence, *ALS_Integration_Time, *ALS_Gain, *PowerSave_Enable,
       *PowerSave_Mode;
-
-  float normalize_resolution(float value);
-
   Adafruit_I2CDevice *i2c_dev;
 };
 

--- a/examples/veml7700_test/veml7700_test.ino
+++ b/examples/veml7700_test/veml7700_test.ino
@@ -3,8 +3,8 @@
 Adafruit_VEML7700 veml = Adafruit_VEML7700();
 
 void setup() {
-  while (!Serial) { delay(10); }
   Serial.begin(115200);
+  while (!Serial) { delay(10); }
   Serial.println("Adafruit VEML7700 Test");
 
   if (!veml.begin()) {
@@ -13,8 +13,12 @@ void setup() {
   }
   Serial.println("Sensor found");
 
-  veml.setGain(VEML7700_GAIN_1);
-  veml.setIntegrationTime(VEML7700_IT_800MS);
+  // == OPTIONAL =====
+  // Can set non-default gain and integration time to
+  // adjust for different lighting conditions.
+  // =================
+  // veml.setGain(VEML7700_GAIN_1_8);
+  // veml.setIntegrationTime(VEML7700_IT_100MS);
 
   Serial.print(F("Gain: "));
   switch (veml.getGain()) {
@@ -43,16 +47,16 @@ void setup() {
 }
 
 void loop() {
-  Serial.print("Lux: "); Serial.println(veml.readLux());
-  Serial.print("White: "); Serial.println(veml.readWhite());
-  Serial.print("Raw ALS: "); Serial.println(veml.readALS());
+  Serial.print("raw ALS: "); Serial.println(veml.readALS());
+  Serial.print("raw white: "); Serial.println(veml.readWhite());
+  Serial.print("lux: "); Serial.println(veml.readLux());
 
   uint16_t irq = veml.interruptStatus();
   if (irq & VEML7700_INTERRUPT_LOW) {
-    Serial.println("** Low threshold"); 
+    Serial.println("** Low threshold");
   }
   if (irq & VEML7700_INTERRUPT_HIGH) {
-    Serial.println("** High threshold"); 
+    Serial.println("** High threshold");
   }
   delay(500);
 }


### PR DESCRIPTION
**BREAKING CHANGES**

This is a step backwards before moving forward again, which will be a follow on PR. The main motivation is to clean things up (be more inline with circuitpython library) as a precursor to improving lux calculations.

This app note is a useful reference:
https://www.vishay.com/docs/84323/designingveml7700.pdf

This PR removes (for now) the non-linear calculation for `lux`. Per the app note above, it only matters for brighter light levels. It will be added back in a follow on PR which is more inline with the app note. There are several PRs (#10, #8, #6) that have attempted implementations. 

The existing approach taken for adjusting `lux` based on gain and integration time seems unnecessarily convoluted. Instead of adjusting the reading to work with a fixed resolution, this PR determines the resolution from gain and integration time. This is what the datasheet shows and what the CircuitPython library does. 

Summary changes:
  * removed `readLuxNormalized()` - this functionality will be replaced in a follow on PR
  * removed `readWhiteNormalized()` - other than the raw register value for WHITE, there is no other documented usage
  * changed `readWhite()` to return raw register value, not finding any documentation to support anything else
  * changed the approach taken to calculate `lux` for different gains/integration times, it now matches the CircuitPython library
  * changed default value for `gain` to be 0.125 - app note seems to suggest this as good starting point 
  * updated example - will fix #13 and comments out gain/integration time setting to indicate optional 
  * maybe other minor ones i can't remember...will rely on code diff :)