### PR TITLE
Add corrected and automatic lux

### DIFF
--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -57,9 +57,11 @@
 #define VEML7700_POWERSAVE_MODE3 0x02 ///< Power saving mode 3
 #define VEML7700_POWERSAVE_MODE4 0x03 ///< Power saving mode 4
 
+typedef enum { VEML_LUX_NORMAL, VEML_LUX_CORRECTED, VEML_LUX_AUTO } luxMethod;
+
 /*!
  *    @brief  Class that stores state and functions for interacting with
- *            VEML7700 Temp Sensor
+ *            VEML7700 Light Sensor
  */
 class Adafruit_VEML7700 {
 public:
@@ -75,8 +77,10 @@ public:
   uint8_t getPersistence(void);
   void setIntegrationTime(uint8_t it);
   uint8_t getIntegrationTime(void);
+  int getIntegrationTimeValue(void);
   void setGain(uint8_t gain);
   uint8_t getGain(void);
+  float getGainValue(void);
   void powerSaveEnable(bool enable);
   bool powerSaveEnabled(void);
   void setPowerSaveMode(uint8_t mode);
@@ -90,13 +94,17 @@ public:
 
   uint16_t readALS();
   uint16_t readWhite();
-  float readLux();
+  float readLux(luxMethod method = VEML_LUX_NORMAL);
 
 private:
   const float MAX_RES = 0.0036;
   const float GAIN_MAX = 2;
   const float IT_MAX = 800;
-  float getResolution();
+  float getResolution(void);
+  float computeLux(uint16_t rawALS, bool corrected = false);
+  float autoLux(void);
+  void readWait(void);
+  unsigned long lastRead;
 
   Adafruit_I2CRegister *ALS_Config, *ALS_Data, *White_Data, *ALS_HighThreshold,
       *ALS_LowThreshold, *Power_Saving, *Interrupt_Status;

--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -57,6 +57,7 @@
 #define VEML7700_POWERSAVE_MODE3 0x02 ///< Power saving mode 3
 #define VEML7700_POWERSAVE_MODE4 0x03 ///< Power saving mode 4
 
+/** Options for lux reading method */
 typedef enum { VEML_LUX_NORMAL, VEML_LUX_CORRECTED, VEML_LUX_AUTO } luxMethod;
 
 /*!

--- a/examples/veml7700_autolux/veml7700_autolux.ino
+++ b/examples/veml7700_autolux/veml7700_autolux.ino
@@ -1,3 +1,13 @@
+/* VEML7700 Auto Lux Example
+ *
+ * This example sketch demonstrates reading lux using the automatic
+ * method which adjusts gain and integration time as needed to obtain
+ * a good reading. A non-linear correction is also applied if needed.
+ *
+ * See Vishy App Note "Designing the VEML7700 Into an Application"
+ * Vishay Document Number: 84323, Fig. 24 Flow Chart
+ */
+
 #include "Adafruit_VEML7700.h"
 
 Adafruit_VEML7700 veml = Adafruit_VEML7700();
@@ -5,21 +15,22 @@ Adafruit_VEML7700 veml = Adafruit_VEML7700();
 void setup() {
   Serial.begin(115200);
   while (!Serial) { delay(10); }
-  Serial.println("Adafruit VEML7700 Test");
+  Serial.println("Adafruit VEML7700 Auto Lux Test");
 
   if (!veml.begin()) {
     Serial.println("Sensor not found");
     while (1);
   }
   Serial.println("Sensor found");
+}
 
-  // == OPTIONAL =====
-  // Can set non-default gain and integration time to
-  // adjust for different lighting conditions.
-  // =================
-  // veml.setGain(VEML7700_GAIN_1_8);
-  // veml.setIntegrationTime(VEML7700_IT_100MS);
+void loop() {
+  // to read lux using automatic method, specify VEML_LUX_AUTO
+  float lux = veml.readLux(VEML_LUX_AUTO);
 
+  Serial.println("------------------------------------");
+  Serial.print("Lux = "); Serial.println(lux);
+  Serial.println("Settings used for reading:");
   Serial.print(F("Gain: "));
   switch (veml.getGain()) {
     case VEML7700_GAIN_1: Serial.println("1"); break;
@@ -27,7 +38,6 @@ void setup() {
     case VEML7700_GAIN_1_4: Serial.println("1/4"); break;
     case VEML7700_GAIN_1_8: Serial.println("1/8"); break;
   }
-
   Serial.print(F("Integration Time (ms): "));
   switch (veml.getIntegrationTime()) {
     case VEML7700_IT_25MS: Serial.println("25"); break;
@@ -38,22 +48,5 @@ void setup() {
     case VEML7700_IT_800MS: Serial.println("800"); break;
   }
 
-  veml.setLowThreshold(10000);
-  veml.setHighThreshold(20000);
-  veml.interruptEnable(true);
-}
-
-void loop() {
-  Serial.print("raw ALS: "); Serial.println(veml.readALS());
-  Serial.print("raw white: "); Serial.println(veml.readWhite());
-  Serial.print("lux: "); Serial.println(veml.readLux());
-
-  uint16_t irq = veml.interruptStatus();
-  if (irq & VEML7700_INTERRUPT_LOW) {
-    Serial.println("** Low threshold");
-  }
-  if (irq & VEML7700_INTERRUPT_HIGH) {
-    Serial.println("** High threshold");
-  }
-  delay(500);
+  delay(1000);
 }


### PR DESCRIPTION
This is a follow on to PR #14.

The previous `readLuxNormalized()` function is added back and is accessed using the new `method` parameter of `readLux()`:
```cpp
lux = readLux(VEML_LUX_CORRECTED);
```

Additionally, the automatic lux algorithm from Vishay App Note "Designing the VEML7700 Into an Application", Document Number: 84323, Fig. 24 Flow Chart, is implemented and also accessed using the `method` parameter:
```cpp
lux = readLux(VEML_LUX_AUTO);
```
A new example sketch `veml7700_autolux` has been added to demonstrate this.

Also some other misc clean up and refactoring.