### PR TITLE
Support reading without waiting

### DIFF
--- a/Adafruit_VEML7700.cpp
+++ b/Adafruit_VEML7700.cpp
@@ -88,11 +88,16 @@ bool Adafruit_VEML7700::begin(TwoWire *theWire) {
  *    @returns Floating point Lux data
  */
 float Adafruit_VEML7700::readLux(luxMethod method) {
+  bool wait = true;
   switch (method) {
+  case VEML_LUX_NORMAL_NOWAIT:
+    wait = false;
   case VEML_LUX_NORMAL:
-    return computeLux(readALS());
+    return computeLux(readALS(wait));
+  case VEML_LUX_CORRECTED_NOWAIT:
+    wait = false;
   case VEML_LUX_CORRECTED:
-    return computeLux(readALS(), true);
+    return computeLux(readALS(wait), true);
   case VEML_LUX_AUTO:
     return autoLux();
   default:
@@ -102,20 +107,28 @@ float Adafruit_VEML7700::readLux(luxMethod method) {
 
 /*!
  *    @brief Read the raw ALS data
+ *    @param wait If false (default), read out measurement with no delay. If
+ * true, wait as need based on integration time before reading out measurement
+ * results.
  *    @returns 16-bit data value from the ALS register
  */
-uint16_t Adafruit_VEML7700::readALS() {
-  readWait();
+uint16_t Adafruit_VEML7700::readALS(bool wait) {
+  if (wait)
+    readWait();
   lastRead = millis();
   return ALS_Data->read();
 }
 
 /*!
  *    @brief Read the raw white light data
+ *    @param wait If false (default), read out measurement with no delay. If
+ * true, wait as need based on integration time before reading out measurement
+ * results.
  *    @returns 16-bit data value from the WHITE register
  */
-uint16_t Adafruit_VEML7700::readWhite() {
-  readWait();
+uint16_t Adafruit_VEML7700::readWhite(bool wait) {
+  if (wait)
+    readWait();
   lastRead = millis();
   return White_Data->read();
 }

--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -58,7 +58,13 @@
 #define VEML7700_POWERSAVE_MODE4 0x03 ///< Power saving mode 4
 
 /** Options for lux reading method */
-typedef enum { VEML_LUX_NORMAL, VEML_LUX_CORRECTED, VEML_LUX_AUTO } luxMethod;
+typedef enum {
+  VEML_LUX_NORMAL,
+  VEML_LUX_CORRECTED,
+  VEML_LUX_AUTO,
+  VEML_LUX_NORMAL_NOWAIT,
+  VEML_LUX_CORRECTED_NOWAIT
+} luxMethod;
 
 /*!
  *    @brief  Class that stores state and functions for interacting with
@@ -93,8 +99,8 @@ public:
   uint16_t getHighThreshold(void);
   uint16_t interruptStatus(void);
 
-  uint16_t readALS();
-  uint16_t readWhite();
+  uint16_t readALS(bool wait = false);
+  uint16_t readWhite(bool wait = false);
   float readLux(luxMethod method = VEML_LUX_NORMAL);
 
 private:


### PR DESCRIPTION
For #16.

This restores behavior that existed prior to the 2.0.0 release, allowing the sensor values to be read without any delay.

Note there is a split in the default behavior:
* `readALS()` and `readWhite()` both default to **no delay**. These are essentially raw register reads, so having no delay here seems OK.
* `readLux()` defaults to **delaying** as needed. This is a computed parameter. So the need to delay to ensure a good reading is probably best to enforce by default.



**EXAMPLE TEST**

```cpp
#include "Adafruit_VEML7700.h"

Adafruit_VEML7700 veml = Adafruit_VEML7700();

void setup() {
  Serial.begin(115200);
  while (!Serial) { delay(10); }
  Serial.println("Adafruit VEML7700 No Wait Test");

  if (!veml.begin()) {
    Serial.println("Sensor not found");
    while (1);
  }
  Serial.println("Sensor found");

  // == OPTIONAL =====
  // Can set non-default gain and integration time to
  // adjust for different lighting conditions.
  // =================
  // veml.setGain(VEML7700_GAIN_1_8);
  // veml.setIntegrationTime(VEML7700_IT_100MS);

  Serial.print(F("Gain: "));
  switch (veml.getGain()) {
    case VEML7700_GAIN_1: Serial.println("1"); break;
    case VEML7700_GAIN_2: Serial.println("2"); break;
    case VEML7700_GAIN_1_4: Serial.println("1/4"); break;
    case VEML7700_GAIN_1_8: Serial.println("1/8"); break;
  }

  Serial.print(F("Integration Time (ms): "));
  switch (veml.getIntegrationTime()) {
    case VEML7700_IT_25MS: Serial.println("25"); break;
    case VEML7700_IT_50MS: Serial.println("50"); break;
    case VEML7700_IT_100MS: Serial.println("100"); break;
    case VEML7700_IT_200MS: Serial.println("200"); break;
    case VEML7700_IT_400MS: Serial.println("400"); break;
    case VEML7700_IT_800MS: Serial.println("800"); break;
  }
}

void loop() {
  unsigned long startTime;

  Serial.println("-------------------------------------------");
  
  startTime = millis();
  Serial.print("Raw ALS without wait: "); Serial.print(veml.readALS());
  Serial.print("  ["); Serial.print(millis() - startTime); Serial.println("ms]");

  startTime = millis();
  Serial.print("Raw ALS with wait: "); Serial.print(veml.readALS(true));
  Serial.print("  ["); Serial.print(millis() - startTime); Serial.println("ms]");

  startTime = millis();
  Serial.print("LUX without wait: "); Serial.print(veml.readLux(VEML_LUX_NORMAL_NOWAIT));
  Serial.print("  ["); Serial.print(millis() - startTime); Serial.println("ms]");

  startTime = millis();
  Serial.print("LUX with wait: "); Serial.print(veml.readLux());
  Serial.print("  ["); Serial.print(millis() - startTime); Serial.println("ms]");

  delay(2000);
}
```

Note the `0` value in the first call to `readALS()` - that's the result of reading too soon.
![Screenshot from 2022-06-02 10-18-43](https://user-images.githubusercontent.com/8755041/171687431-fa478c1c-d91b-4bef-b588-928d4f8b616d.png)

