### PR TITLE
Fix autolux for low light conditions.

### DIFF
--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -82,7 +82,7 @@ public:
   bool interruptEnabled(void);
   void setPersistence(uint8_t pers);
   uint8_t getPersistence(void);
-  void setIntegrationTime(uint8_t it);
+  void setIntegrationTime(uint8_t it, bool wait = true);
   uint8_t getIntegrationTime(void);
   int getIntegrationTimeValue(void);
   void setGain(uint8_t gain);


### PR DESCRIPTION
For #18.

The main issue here was needing additional delay time when switching from a longer integration time to a shorter. Only the new shorter time was being used. But the older, longer cycle may still be in process. So additional delay needed before attempting a new read out of ALS.

This would happen every other cycle in low light, since the final integration time would be long (due to low light). But on the next attempt, the integration time would be reset to the lower initial value and an incorrect ALS reading would result.

Tested with Itsy M4 and autolux example sketch.
![Screenshot from 2022-06-24 10-13-43](https://user-images.githubusercontent.com/8755041/175610888-013310ca-f443-480b-9647-c20c9eb98e49.png)

