### PR TITLE
Fix GCC errors for ESP32

### DIFF
--- a/Adafruit_VEML7700.cpp
+++ b/Adafruit_VEML7700.cpp
@@ -89,13 +89,13 @@ bool Adafruit_VEML7700::begin(TwoWire *theWire) {
  */
 float Adafruit_VEML7700::readLux(luxMethod method) {
   bool wait = true;
-  switch (method) {
-  case VEML_LUX_NORMAL_NOWAIT:
+
+  if (method == VEML_LUX_NORMAL_NOWAIT || method == VEML_LUX_CORRECTED_NOWAIT)
     wait = false;
+
+  switch (method) {
   case VEML_LUX_NORMAL:
     return computeLux(readALS(wait));
-  case VEML_LUX_CORRECTED_NOWAIT:
-    wait = false;
   case VEML_LUX_CORRECTED:
     return computeLux(readALS(wait), true);
   case VEML_LUX_AUTO:

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit VEML7700 Library
-version=2.1.1
+version=2.1.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the VEML7700 sensors in the Adafruit shop


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_VEML7700/issues/21 and retains `readLux()`'s delay as needed functionality.