### PR TITLE
end function to free memory

### DIFF
--- a/Adafruit_VEML7700.cpp
+++ b/Adafruit_VEML7700.cpp
@@ -82,6 +82,27 @@ bool Adafruit_VEML7700::begin(TwoWire *theWire) {
   return true;
 }
 
+ /*!
+ *    @brief  Frees memory to avoid memory leaks
+ */
+void Adafruit_VEML7700::end(void) {
+  delete i2c_dev;
+  delete ALS_Config;
+  delete ALS_HighThreshold;
+  delete ALS_LowThreshold;
+  delete Power_Saving;
+  delete ALS_Data;
+  delete White_Data;
+  delete Interrupt_Status;
+  delete ALS_Shutdown;
+  delete ALS_Interrupt_Enable;
+  delete ALS_Persistence;
+  delete ALS_Integration_Time;
+  delete ALS_Gain;
+  delete PowerSave_Enable;
+  delete PowerSave_Mode;
+}
+
 /*!
  *    @brief Read the calibrated lux value. See app note lux table on page 5
  *    @param method Lux comptation method to use. One of

--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -74,6 +74,7 @@ class Adafruit_VEML7700 {
 public:
   Adafruit_VEML7700();
   bool begin(TwoWire *theWire = &Wire);
+  void end(void);
 
   void enable(bool enable);
   bool enabled(void);


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

> The header and cpp file was altered in order to provide a function that frees all the memory that is allocated in the begin function.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

> This would work for all platforms!

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

> I have tested this with an Arduino with the following code and ran two examples:
> ```cpp
> /* This code eventually leads to the arduino running out of memory and freezing */
> int begin_count = 0
> void loop () {
>     veml.begin()
>     begin_count++;
>     Serial.println(begin_count)
>}
>
>/* This code eventually runs indefinitely! */
>int begin_count = 0
>void loop () {
>     veml.begin()
>     begin_count++;
>     Serial.println(begin_count)
>     veml.end()
>}
>```