### PR TITLE
Revert switch statement in readLux()

### DIFF
--- a/Adafruit_VEML7700.cpp
+++ b/Adafruit_VEML7700.cpp
@@ -89,13 +89,15 @@ bool Adafruit_VEML7700::begin(TwoWire *theWire) {
  */
 float Adafruit_VEML7700::readLux(luxMethod method) {
   bool wait = true;
-
-  if (method == VEML_LUX_NORMAL_NOWAIT || method == VEML_LUX_CORRECTED_NOWAIT)
-    wait = false;
-
   switch (method) {
+  case VEML_LUX_NORMAL_NOWAIT:
+    wait = false;
+    VEML7700_FALLTHROUGH
   case VEML_LUX_NORMAL:
     return computeLux(readALS(wait));
+  case VEML_LUX_CORRECTED_NOWAIT:
+    wait = false;
+    VEML7700_FALLTHROUGH
   case VEML_LUX_CORRECTED:
     return computeLux(readALS(wait), true);
   case VEML_LUX_AUTO:

--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -57,8 +57,10 @@
 #define VEML7700_POWERSAVE_MODE3 0x02 ///< Power saving mode 3
 #define VEML7700_POWERSAVE_MODE4 0x03 ///< Power saving mode 4
 
-// used to explicitly annotate switch case fall throughs
-// newer compilers will throw a warning otherwise
+/*!
+ *  @brief Used to explicitly annotate switch case fall throughs.
+ *         Newer compilers will throw a warning otherwise.
+ */
 #if defined(__GNUC__) && __GNUC__ >= 7
 #define VEML7700_FALLTHROUGH __attribute__((fallthrough));
 #else

--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -57,6 +57,14 @@
 #define VEML7700_POWERSAVE_MODE3 0x02 ///< Power saving mode 3
 #define VEML7700_POWERSAVE_MODE4 0x03 ///< Power saving mode 4
 
+// used to explicitly annotate switch case fall throughs
+// newer compilers will throw a warning otherwise
+#if defined(__GNUC__) && __GNUC__ >= 7
+#define VEML7700_FALLTHROUGH __attribute__((fallthrough));
+#else
+#define VEML7770_FALLTHROUGH
+#endif
+
 /** Options for lux reading method */
 typedef enum {
   VEML_LUX_NORMAL,


### PR DESCRIPTION
For #26.

Reverts to the original switch case logic and adds a shush to suppress the compiler warn.

Tested using issue example sketch on QT Py ESP32. The last two readings are no longer returning -1:
![Screenshot from 2023-06-23 09-54-02](https://github.com/adafruit/Adafruit_VEML7700/assets/8755041/d15dd952-92e6-4b8d-853a-3a8cb4ca3cc0)

And, afaik, compiler is still happy?
