### PR TITLE
fix typos ("persistence")

### DIFF
--- a/Adafruit_VEML7700.cpp
+++ b/Adafruit_VEML7700.cpp
@@ -175,8 +175,8 @@ bool Adafruit_VEML7700::interruptEnabled(void) {
 }
 
 /*!
- *    @brief Set the ALS IRQ persistance setting
- *    @param pers Persistance constant, can be VEML7700_PERS_1, VEML7700_PERS_2,
+ *    @brief Set the ALS IRQ persistence setting
+ *    @param pers Persistence constant, can be VEML7700_PERS_1, VEML7700_PERS_2,
  *    VEML7700_PERS_4 or VEML7700_PERS_8
  */
 void Adafruit_VEML7700::setPersistence(uint8_t pers) {
@@ -184,8 +184,8 @@ void Adafruit_VEML7700::setPersistence(uint8_t pers) {
 }
 
 /*!
- *    @brief Get the ALS IRQ persistance setting
- *    @returns Persistance constant, can be VEML7700_PERS_1, VEML7700_PERS_2,
+ *    @brief Get the ALS IRQ persistence setting
+ *    @returns Persistence constant, can be VEML7700_PERS_1, VEML7700_PERS_2,
  *    VEML7700_PERS_4 or VEML7700_PERS_8
  */
 uint8_t Adafruit_VEML7700::getPersistence(void) {

--- a/Adafruit_VEML7700.h
+++ b/Adafruit_VEML7700.h
@@ -47,10 +47,10 @@
 #define VEML7700_IT_50MS 0x08  ///< ALS intetgration time 50ms
 #define VEML7700_IT_25MS 0x0C  ///< ALS intetgration time 25ms
 
-#define VEML7700_PERS_1 0x00 ///< ALS irq persisance 1 sample
-#define VEML7700_PERS_2 0x01 ///< ALS irq persisance 2 samples
-#define VEML7700_PERS_4 0x02 ///< ALS irq persisance 4 samples
-#define VEML7700_PERS_8 0x03 ///< ALS irq persisance 8 samples
+#define VEML7700_PERS_1 0x00 ///< ALS irq persistence 1 sample
+#define VEML7700_PERS_2 0x01 ///< ALS irq persistence 2 samples
+#define VEML7700_PERS_4 0x02 ///< ALS irq persistence 4 samples
+#define VEML7700_PERS_8 0x03 ///< ALS irq persistence 8 samples
 
 #define VEML7700_POWERSAVE_MODE1 0x00 ///< Power saving mode 1
 #define VEML7700_POWERSAVE_MODE2 0x01 ///< Power saving mode 2


### PR DESCRIPTION
I noticed some inconsistencies with the word "persistence". I'm not entirely sure, if "persistance" is wrong, but "persistence" seems to be the more prevalent version. Thats also what the method names use. So I adjusted every mention of persistence in the comments accordingly.

:)